### PR TITLE
Add SQLite database caching option

### DIFF
--- a/Read_me.md
+++ b/Read_me.md
@@ -28,3 +28,24 @@ The MACD value should be below the MACD signal line.
 The MACD value should be above 0.
 The 10-day and the 30-day SMA should be below the 50-day SMA.
 The 10-day, 30-day, and 50-day SMA should be above the 200-day SMA.
+## Database Caching
+
+The application can store downloaded price data in a local SQLite database.  Using a database avoids repeatedly downloading the same history and speeds up subsequent runs.
+
+Use the `--db-path` option to specify the location of the SQLite file when running `project_alpha.py`:
+
+```bash
+python src/project_alpha.py --db-path my_data.db
+```
+
+If a database is provided, new prices are fetched only for dates that are not already stored. All historical data will be read from the database instead of relying solely on pickle caches.
+
+### Migrating old cache files
+
+For existing pickle caches you can populate a new database with the helper script:
+
+```bash
+python scripts/migrate_pickle_to_db.py <pickle_file> <database>
+```
+
+This script reads the old cached dictionary and inserts its contents into the SQLite tables.

--- a/scripts/migrate_pickle_to_db.py
+++ b/scripts/migrate_pickle_to_db.py
@@ -1,0 +1,33 @@
+import argparse
+import pickle
+from classes.DatabaseManager import (
+    connect_db,
+    create_tables,
+    insert_price_rows,
+    insert_company_info,
+)
+
+
+def migrate(pickle_file: str, db_path: str) -> None:
+    with open(pickle_file, "rb") as f:
+        data = pickle.load(f)
+
+    conn = connect_db(db_path)
+    create_tables(conn)
+
+    for symbol, df in data.get("price_data", {}).items():
+        insert_price_rows(conn, symbol, df)
+
+    for symbol, info in data.get("company_info", {}).items():
+        insert_company_info(conn, symbol, info)
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Migrate pickle cache to SQLite")
+    parser.add_argument("pickle_file", help="Existing pickle data file")
+    parser.add_argument("db_path", help="SQLite database path")
+    args = parser.parse_args()
+    migrate(args.pickle_file, args.db_path)
+

--- a/src/classes/DatabaseManager.py
+++ b/src/classes/DatabaseManager.py
@@ -1,0 +1,128 @@
+import sqlite3
+import pandas as pd
+import json
+from typing import Optional
+
+
+def connect_db(db_path: str) -> sqlite3.Connection:
+    """Return a connection to the SQLite database at ``db_path``."""
+    return sqlite3.connect(db_path)
+
+
+def create_tables(conn: sqlite3.Connection) -> None:
+    """Create required tables if they do not already exist."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS price_data(
+            symbol TEXT,
+            date TEXT,
+            open REAL,
+            high REAL,
+            low REAL,
+            close REAL,
+            adj_close REAL,
+            volume REAL,
+            dividends REAL,
+            splits REAL,
+            PRIMARY KEY(symbol, date)
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS company_info(
+            symbol TEXT PRIMARY KEY,
+            info_json TEXT
+        )
+        """
+    )
+    conn.commit()
+
+
+def get_last_date(conn: sqlite3.Connection, symbol: str) -> Optional[str]:
+    """Return the latest date stored for ``symbol`` or ``None``."""
+    cur = conn.cursor()
+    cur.execute("SELECT MAX(date) FROM price_data WHERE symbol=?", (symbol,))
+    row = cur.fetchone()
+    return row[0] if row and row[0] else None
+
+
+def insert_price_rows(conn: sqlite3.Connection, symbol: str, df: pd.DataFrame) -> None:
+    """Insert or replace rows from ``df`` into ``price_data``."""
+    if df is None or df.empty:
+        return
+    df = df.copy()
+    if df.index.name is None:
+        df.index.name = "date"
+    df.reset_index(inplace=True)
+    df.columns = [c.lower().replace(" ", "_") for c in df.columns]
+    df["symbol"] = symbol
+    records = df[
+        [
+            "symbol",
+            "date",
+            "open",
+            "high",
+            "low",
+            "close",
+            "adj_close",
+            "volume",
+            "dividends",
+            "stock_splits" if "stock_splits" in df.columns else "splits",
+        ]
+    ].values.tolist()
+    sql = (
+        "INSERT OR REPLACE INTO price_data "
+        "(symbol, date, open, high, low, close, adj_close, volume, dividends, splits) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+    )
+    conn.executemany(sql, records)
+    conn.commit()
+
+
+def insert_company_info(conn: sqlite3.Connection, symbol: str, info: dict) -> None:
+    """Insert or replace company info."""
+    if not info:
+        return
+    data = json.dumps(info)
+    conn.execute(
+        "INSERT OR REPLACE INTO company_info(symbol, info_json) VALUES(?, ?)",
+        (symbol, data),
+    )
+    conn.commit()
+
+
+def get_price_dataframe(conn: sqlite3.Connection, symbol: str) -> pd.DataFrame:
+    """Return a DataFrame of historical prices for ``symbol``."""
+    query = (
+        "SELECT date, open, high, low, close, adj_close, volume, dividends, splits "
+        "FROM price_data WHERE symbol=? ORDER BY date"
+    )
+    df = pd.read_sql_query(query, conn, params=(symbol,))
+    if df.empty:
+        return pd.DataFrame()
+    df["date"] = pd.to_datetime(df["date"])
+    df.set_index("date", inplace=True)
+    df.rename(
+        columns={
+            "open": "Open",
+            "high": "High",
+            "low": "Low",
+            "close": "Close",
+            "adj_close": "Adj Close",
+            "volume": "Volume",
+            "dividends": "Dividends",
+            "splits": "Stock Splits",
+        },
+        inplace=True,
+    )
+    return df
+
+
+def get_company_info(conn: sqlite3.Connection, symbol: str) -> Optional[dict]:
+    cur = conn.cursor()
+    cur.execute("SELECT info_json FROM company_info WHERE symbol=?", (symbol,))
+    row = cur.fetchone()
+    return json.loads(row[0]) if row else None
+

--- a/src/project_alpha.py
+++ b/src/project_alpha.py
@@ -69,6 +69,11 @@ def cli_argparser():
         help="Use cached data and parameters if available.",
     )
     cli.add_argument(
+        "--db-path",
+        type=str,
+        help="Path to SQLite database for storing price data.",
+    )
+    cli.add_argument(
         "--value",
         action="store_true",
         help="Plot and send value stocks from external source.",
@@ -77,7 +82,7 @@ def cli_argparser():
 
 
 
-def screener_value_charts(cache, market: str, index: str, symbols: list):
+def screener_value_charts(cache, market: str, index: str, symbols: list, db_path: str = None):
     """
     Screener value charts for a given market, index, and list of symbols.
 
@@ -95,7 +100,7 @@ def screener_value_charts(cache, market: str, index: str, symbols: list):
         os.mkdir(historic_data_dir)
     
     file_prefix = f"{index}_data"
-    data = load_data(cache, symbols, market, file_prefix, historic_data_dir)
+    data = load_data(cache, symbols, market, file_prefix, historic_data_dir, db_path=db_path)
     
     price_data = data["price_data"]
     value_symbols = data["tickers"]
@@ -114,6 +119,7 @@ def main():
     args = cli_argparser()
     cache = args.cache
     market = args.market
+    db_path = args.db_path
 
     # Load data
     if market == "india":
@@ -121,7 +127,7 @@ def main():
         screener_dur = 3
         if args.value:
             value_index, value_symbols = Index.ind_screener_value_stocks()
-            screener_value_charts(cache, market, value_index, value_symbols)
+            screener_value_charts(cache, market, value_index, value_symbols, db_path)
     else:
         index, symbols = Index.sp_500()
         screener_dur = 3
@@ -130,7 +136,7 @@ def main():
         os.mkdir(f"data/historic_data/{market}")
     data_dir = f"data/historic_data/{market}"
     file_prifix = f"{index}_data"
-    data = load_data(cache, symbols, market, file_prifix, data_dir)
+    data = load_data(cache, symbols, market, file_prifix, data_dir, db_path=db_path)
 
     # Start processing data
     print("\nStarting Volatility based screening...")


### PR DESCRIPTION
## Summary
- add `DatabaseManager` module for SQLite storage
- persist price and company info into SQLite in `Download`
- read data back from SQLite in `load_data`
- support `--db-path` option in CLI
- document how to enable the database and migrate old cache
- provide `migrate_pickle_to_db.py` helper

## Testing
- `python -m py_compile src/classes/DatabaseManager.py src/classes/Download.py src/project_alpha.py scripts/migrate_pickle_to_db.py`

------
https://chatgpt.com/codex/tasks/task_e_6842f784d7948333b33ceaa1b7476f05