### PR TITLE
Fix typo in Screener_value comment

### DIFF
--- a/src/classes/Screener_value.py
+++ b/src/classes/Screener_value.py
@@ -16,7 +16,7 @@ def get_value_screener_data(statistics, balance_sheet, income_statement):
     try:
         capital_employed = balance_sheet.loc['Total Assets'] - balance_sheet.loc['Total Debt']
         roce = (income_statement.loc['Net Income'] / capital_employed).tolist()
-        # calcullate average of list of roce
+        # calculate average of list of roce
         aroce = sum(roce) / len(roce)
         ticker_data["AROCE"] = aroce
     except Exception as e:


### PR DESCRIPTION
## Summary
- fix misspelled word in Screener_value comment

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843013acbd8833389459a5c2f26b1c5