### PR TITLE
Fix variable issue in moving average screener

### DIFF
--- a/src/classes/Screener_ma.py
+++ b/src/classes/Screener_ma.py
@@ -40,6 +40,7 @@ def backtest_signals(row):
 
     trades = []
     holding_period = 14
+    trade_in_progress = False
 
     if trade_in_progress:
         _data = trades[-1]
@@ -73,7 +74,7 @@ def backtest_signals(row):
                     "stock": row["stock"],
                 }
             )
-
+    return trades
 
 def find_stocks_meeting_conditions(data, signals, lookback_days):
     matching_stocks = []


### PR DESCRIPTION
## Summary
- fix undefined `trade_in_progress` variable and add return statement in `backtest_signals`
- run `py_compile` on updated files

## Testing
- `python -m py_compile src/classes/Screener_ma.py`
- `python -m py_compile src/project_alpha.py src/classes/Tools.py src/classes/Send_email.py src/classes/Screener_ma.py`


------
https://chatgpt.com/codex/tasks/task_e_6842f2415ec083339025686a614700e2