### PR TITLE
Fix volatile table saving logic

### DIFF
--- a/src/classes/Volatile.py
+++ b/src/classes/Volatile.py
@@ -522,25 +522,25 @@ def volatile(
         if i < num_stocks - 1 and ranked_rates[i] != ranked_rates[i + 1]:
             print(separator)
     '''
+    # Creating a DataFrame for the prediction table
+    data = {
+        "SYMBOL": ranked_tickers.tolist(),
+        "SECTOR": ranked_sectors,
+        "INDUSTRY": ranked_industries,
+        "PRICE": [
+            "{} {}".format(np.round(ranked_p[i, -1], 2), ranked_currencies[i])
+            for i in range(num_stocks)
+        ],
+        "RATE": ranked_rates,
+        "GROWTH": ranked_growth.tolist(),
+        "VOLATILITY": ranked_volatility.tolist(),
+        "MATCH": (ranked_matches.tolist() if num_stocks > 1 else ["None"]),
+    }
+
+    volatile_df = pd.DataFrame(data)
+
     if args.save_table:
         tab_name = "data/processed_data/volatile/prediction_table.csv"
-
-        # Creating a DataFrame
-        data = {
-            "SYMBOL": ranked_tickers.tolist(),
-            "SECTOR": ranked_sectors,
-            "INDUSTRY": ranked_industries,
-            "PRICE": [
-                "{} {}".format(np.round(ranked_p[i, -1], 2), ranked_currencies[i])
-                for i in range(num_stocks)
-            ],
-            "RATE": ranked_rates,
-            "GROWTH": ranked_growth.tolist(),
-            "VOLATILITY": ranked_volatility.tolist(),
-            "MATCH": (ranked_matches.tolist() if num_stocks > 1 else ["None"]),
-        }
-
-        volatile_df = pd.DataFrame(data)
 
         # Save the DataFrame to a CSV file
         volatile_df.to_csv(tab_name, index=False)


### PR DESCRIPTION
## Summary
- in `Volatile.volatile()`, build the prediction table dataframe unconditionally
- only save the dataframe to CSV when `--save-table` is set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f29b23b008333adc65d96f05b2cb5