### PR TITLE
Add model persistence options

### DIFF
--- a/Read_me.md
+++ b/Read_me.md
@@ -49,3 +49,13 @@ python scripts/migrate_pickle_to_db.py <pickle_file> <database>
 ```
 
 This script reads the old cached dictionary and inserts its contents into the SQLite tables.
+
+## Saving and Loading Model Parameters
+
+Training the volatility model can be time consuming.  You can save the learned
+parameters to disk and reuse them in later runs.
+
+Use `--save-model <file>` to write the parameters after training and
+`--load-model <file>` to initialize training from a previous run.  Providing
+saved parameters allows you to resume training, reduces start-up time and
+enables incremental learning on new data.


### PR DESCRIPTION
## Summary
- allow `train_msis_mcs` to start from provided parameters
- expose `--load-model` and `--save-model` CLI flags in `Volatile`
- persist/load model parameters to resume training
- document new options in README

## Testing
- `python -m py_compile src/classes/Models.py src/classes/Volatile.py`


------
https://chatgpt.com/codex/tasks/task_e_684f2de036e083338ef547e6584da86d