### PR TITLE
Fix Python 3.9 type hint

### DIFF
--- a/src/classes/Models.py
+++ b/src/classes/Models.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import tensorflow as tf
 import tensorflow_probability as tfp
 from tensorflow_probability import distributions as tfd
+from typing import Optional
 
 def s_model(info: dict) -> tfd.JointDistributionSequentialAutoBatched:
     """
@@ -140,7 +141,7 @@ def train_msis_mcs(
     learning_rate: float = 0.01,
     num_steps: int = 10000,
     plot_losses: bool = False,
-    initial_params: tuple | None = None,
+    initial_params: Optional[tuple] = None,
 ) -> tuple:
     """
     It performs sequential optimization over the model parameters via Adam optimizer, training at different levels to


### PR DESCRIPTION
## Summary
- add Optional import for compatibility
- fix train_msis_mcs signature for Python 3.9

## Testing
- `python3 -m py_compile $(git ls-files 'src/**/*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f3be67f188333a03684202dde0fac