### PR TITLE
Fix missing load_model arg

### DIFF
--- a/src/project_alpha.py
+++ b/src/project_alpha.py
@@ -69,6 +69,16 @@ def cli_argparser():
         help="Use cached data and parameters if available.",
     )
     cli.add_argument(
+        "--load-model",
+        type=str,
+        help="Path to a pickle file with previously saved model parameters.",
+    )
+    cli.add_argument(
+        "--save-model",
+        type=str,
+        help="Destination path to save trained model parameters.",
+    )
+    cli.add_argument(
         "--db-path",
         type=str,
         help="Path to SQLite database for storing price data.",


### PR DESCRIPTION
## Summary
- add --load-model and --save-model options to CLI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684f417d3a8c8333893ebf76c7b10d95