### PR TITLE
Fix Keras optimizer import

### DIFF
--- a/src/classes/Models.py
+++ b/src/classes/Models.py
@@ -167,7 +167,7 @@ def train_msis_mcs(
     -------
     It returns a tuple of trained parameters.
     """
-    optimizer = tf.keras.optimizers.legacy.Adam(learning_rate=learning_rate)
+    optimizer = tf.keras.optimizers.Adam(learning_rate=learning_rate)
     num_steps_l = int(np.ceil(num_steps // 4))
 
     # market


### PR DESCRIPTION
## Summary
- use `tf.keras.optimizers.Adam` now that Keras 3 removed the legacy module

## Testing
- `python -m py_compile src/classes/Models.py`


------
https://chatgpt.com/codex/tasks/task_e_684f43dd14e083339b9225a454aa01b8