### PR TITLE
Create database if directory is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Logged executions are provided via helper shell scripts
 
 ## Database Caching
 
-Price data can be saved in an SQLite file using `--db-path`.  The
-`migrate_pickle_to_db.py` script converts existing pickle caches to the new
+Price data can be saved in an SQLite file using `--db-path`.  The database
+file will be created automatically along with any missing parent directories.
+The `migrate_pickle_to_db.py` script converts existing pickle caches to the new
 format.
 
 ## Output

--- a/src/classes/DatabaseManager.py
+++ b/src/classes/DatabaseManager.py
@@ -2,10 +2,18 @@ import sqlite3
 import pandas as pd
 import json
 from typing import Optional
+import os
 
 
 def connect_db(db_path: str) -> sqlite3.Connection:
-    """Return a connection to the SQLite database at ``db_path``."""
+    """Return a connection to the SQLite database at ``db_path``.
+
+    Any missing parent directories are created automatically so that a new
+    database file can be initialised without manual setup.
+    """
+    parent = os.path.dirname(db_path)
+    if parent and not os.path.exists(parent):
+        os.makedirs(parent, exist_ok=True)
     return sqlite3.connect(db_path)
 
 


### PR DESCRIPTION
## Summary
- auto-create the database directory in `connect_db`
- note automatic database creation in README

## Testing
- `pytest -q`
- `python -m pip install -e .`

------
https://chatgpt.com/codex/tasks/task_e_68502174b90083339bd1fe8cdf1c0779