### PR TITLE
Add Open WebUI plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ model experimentation.  They are optional for running the basic pipeline.
 
 Project Alpha is provided for educational purposes only and does not constitute
 financial advice.
+
+## Web Interface with Open WebUI
+
+This project ships an optional [Open WebUI](https://github.com/open-webui/open-webui) plugin located in `webui_plugins/project_alpha_pipeline.py`. After installing the `open-webui` package, you can launch the UI and load the plugin with:
+
+```bash
+pip install open-webui
+open-webui --plugins webui_plugins
+```
+
+The plugin exposes tools to run the stock scanner and fetch the latest trending symbols directly from the interface.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "scikit-learn (>=1.7.0,<2.0.0)",
     "joblib (>=1.5.1,<2.0.0)",
     "advanced-ta (==0.1.8)",
-    "scipy (>=1.15.3,<2.0.0)"
+    "scipy (>=1.15.3,<2.0.0)",
+    "open-webui (>=0.6.15,<0.7.0)"
 ]
 
 

--- a/webui_plugins/project_alpha_pipeline.py
+++ b/webui_plugins/project_alpha_pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import os
+import subprocess
+import pandas as pd
+from blueprints.function_calling_blueprint import Pipeline as FunctionCallingBlueprint
+
+class Pipeline(FunctionCallingBlueprint):
+    """Open WebUI pipeline to run Project Alpha tasks."""
+
+    class Valves(FunctionCallingBlueprint.Valves):
+        MARKET: str = "us"
+        pass
+
+    class Tools:
+        def __init__(self, pipeline: 'Pipeline') -> None:
+            self.pipeline = pipeline
+
+        def run_full_scan(self, market: str | None = None) -> str:
+            """Run the stock scanner for the given market."""
+            market = market or self.pipeline.valves.MARKET
+            cmd = ["python", "src/project_alpha.py", "--market", market]
+            result = subprocess.run(cmd, capture_output=True, text=True)
+            return result.stdout
+
+        def get_latest_trending(self, limit: int = 10) -> list[str]:
+            """Return the latest trending symbols."""
+            market = self.pipeline.valves.MARKET
+            fname = f"data/historic_results/{market}/screener_trend.csv"
+            if not os.path.exists(fname):
+                return []
+            df = pd.read_csv(fname, header=None)
+            if df.empty:
+                return []
+            last_row = df.tail(1).iloc[0, 1:].dropna()
+            return last_row.tolist()[:limit]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "Project Alpha Pipeline"
+        self.valves = self.Valves(**{**self.valves.model_dump()})
+        self.tools = self.Tools(self)


### PR DESCRIPTION
## Summary
- create `project_alpha_pipeline` Open WebUI plugin
- install `open-webui` dependency
- document using Open WebUI in README

## Testing
- `python -m py_compile webui_plugins/project_alpha_pipeline.py`

------
https://chatgpt.com/codex/tasks/task_e_685b2a3a3f70833389013eb565cd3e95